### PR TITLE
Move custom option to top of list

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -116,6 +116,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       allowCustomValue={model.state.allowCustomValue ?? true}
       isValidNewOption={(inputValue) => inputValue.trim().length > 0}
       allowCreateWhileLoading
+      createOptionPosition="first"
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
       disabled={model.state.readOnly}
       className={cx(styles.value, isValuesOpen ? styles.widthWhenOpen : undefined)}


### PR DESCRIPTION
## Description of Change

Currently, when Grafana dashboard filters show a new custom option, it shows up at the bottom of the list

This PR updates this behaviour to move the custom value to the top of the list, for ease of use